### PR TITLE
refactor(file-context-sync): 외부 변경 감지 알림 메시지 톤 강화

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Claude Code에 마켓플레이스 등록
 | 플러그인 | 버전 | 설명 |
 |---------|-----|------|
 | auto-test-generator | 0.1.0 | 시나리오 기반 테스트 코드 자동 생성 플러그인 |
-| file-context-sync | 0.1.0 | 파일 외부 변경 감지 플러그인 |
+| file-context-sync | 0.1.1 | 파일 외부 변경 감지 플러그인 |
 | git | 1.0.1 | Git 작업 편의 기능을 제공하는 플러그인 |
 | python-quality-pack | 0.1.0 | Python 개발 품질 향상을 위한 도구 모음 |
 

--- a/plugins/file-context-sync/.claude-plugin/plugin.json
+++ b/plugins/file-context-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "file-context-sync",
     "description": "Claude가 읽거나 수정한 파일의 외부 변경을 감지하는 플러그인",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "author": {
         "name": "JiseonLee"
     },

--- a/plugins/file-context-sync/README.md
+++ b/plugins/file-context-sync/README.md
@@ -203,7 +203,7 @@ Claude가 Read/Edit/Write/MultiEdit 도구를 사용한 후 파일 상태를 저
 {
   "hookSpecificOutput": {
     "hookEventName": "UserPromptSubmit",
-    "additionalContext": "The following files have been modified externally:\n- src/main.py\n- src/utils.py (deleted)\n\nPlease check the current state of these files."
+    "additionalContext": "[CONTEXT SYNC] Files modified externally since last read:\n  - src/main.py\n  - src/utils.py (deleted)\n\nYou MUST re-read these files before responding. Your cached knowledge is outdated."
   }
 }
 ```

--- a/plugins/file-context-sync/scripts/detect_changes.py
+++ b/plugins/file-context-sync/scripts/detect_changes.py
@@ -117,18 +117,20 @@ def main() -> None:
 
 def format_message(changed_files: list, deleted_files: list, cwd: str) -> str:
     """Format the warning message for changed/deleted files."""
-    lines = ["The following files have been modified externally:"]
+    lines = ["[CONTEXT SYNC] Files modified externally since last read:"]
 
     for file_path in changed_files:
         rel_path = get_relative_path(file_path, cwd)
-        lines.append(f"- {rel_path}")
+        lines.append(f"  - {rel_path}")
 
     for file_path in deleted_files:
         rel_path = get_relative_path(file_path, cwd)
-        lines.append(f"- {rel_path} (deleted)")
+        lines.append(f"  - {rel_path} (deleted)")
 
     lines.append("")
-    lines.append("Please check the current state of these files.")
+    lines.append(
+        "You MUST re-read these files before responding. Your cached knowledge is outdated."
+    )
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## 1. 개요

file-context-sync 플러그인의 외부 변경 감지 알림 메시지를 권유형에서 명령형으로 변경하여 Claude가 알림을 무시하지 않도록 개선합니다.

## 2. 주요 변경 사항

- **헤더 변경**: `The following files have been modified externally:` -> `[CONTEXT SYNC] Files modified externally since last read:`
- **지시문 강화**: `Please check the current state of these files.` -> `You MUST re-read these files before responding. Your cached knowledge is outdated.`
- **파일 목록 들여쓰기 추가**: `- path` -> `  - path`

## 3. 테스트

- [ ] 외부에서 파일 수정 후 메시지 전송 시 새 형식으로 알림 출력 확인
- [ ] Claude가 알림을 인식하고 파일을 다시 읽는지 확인