### PR TITLE
refactor: pr-convention 스킬 제약사항 상단 이동 및 설명 간소화

### DIFF
--- a/plugins/git/skills/pr-convention/SKILL.md
+++ b/plugins/git/skills/pr-convention/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: pr-convention
-description: Use when creating GitHub pull requests. Provides PR title, body format, and labeling conventions.
+description: Use when creating or editing GitHub pull requests. Provides PR conventions.
 ---
+
+## Constraints (CRITICAL)
+
+- NEVER include phrases like `Generated with Claude Code` or `Co-Authored-By: Claude` in PR messages
+
 
 ## Format
 
@@ -62,7 +67,3 @@ Examples:
 | development | Development environment setup |
 | documentation | Add or modify documentation (including comments) |
 | ignore-for-release | Exclude from release changelog (mainly internal config changes) |
-
-
-## Constraints
-- MUST EXCLUDE phrases like `Generated with Claude Code` or `Co-Authored-By: Claude` in PR messages


### PR DESCRIPTION
## 1. 개요

**변경 내용**
pr-convention 스킬의 Constraints 섹션 위치를 문서 상단으로 이동하고, 설명 문구를 간소화함.

**배경**
PR 메세지에 Claude 관련 문구를 포함하지 말아야 한다는 중요한 제약사항이 문서 하단에 위치하여 쉽게 간과될 수 있었음.

## 2. 주요 변경 사항
- Constraints 섹션을 문서 최상단으로 이동하여 가시성 향상
- description 문구를 간결하게 수정
- MUST EXCLUDE 표현을 NEVER로 변경하여 명확성 강화

## 3. 테스트
없음