### PR TITLE
fix: pr.md의 gh pr view 명령어 에러 처리 및 allowed-tools 수정

### DIFF
--- a/plugins/git/commands/pr.md
+++ b/plugins/git/commands/pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git push:*), Bash(gh pr create:*), Bash(gh pr edit:*)
+allowed-tools: Bash(git push:*), Bash(gh pr veiw:*), Bash(gh pr create:*), Bash(gh pr edit:*)
 description: Create or Edit PR
 ---
 
@@ -9,7 +9,7 @@ description: Create or Edit PR
 - Commits in this branch (not in main): !`git log origin/HEAD..HEAD --oneline`
 - Changes summary: !`git diff origin/HEAD..HEAD --stat`
 - Detailed changes: !`git diff origin/HEAD..HEAD`
-- Existing PR: !`gh pr view`
+- Existing PR: !`gh pr view 2>/dev/null || echo "No PR exists for this branch"`
 
 ## Your task
 

--- a/plugins/git/commands/pr.md
+++ b/plugins/git/commands/pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git push:*), Bash(gh pr veiw:*), Bash(gh pr create:*), Bash(gh pr edit:*)
+allowed-tools: Bash(git push:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*)
 description: Create or Edit PR
 ---
 


### PR DESCRIPTION
## 1. 개요

PR 생성/편집 커맨드(pr.md)에서 `gh pr view` 명령어 실행 시 발생하는 권한 오류를 수정합니다.

## 2. 주요 변경 사항

- `allowed-tools`에 `Bash(gh pr view:*)` 추가하여 gh pr view 명령어 실행 권한 부여
- 기존 PR 확인 섹션에서 에러 발생 시 대체 텍스트를 표시하도록 수정

## 3. 테스트

- PR이 없는 브랜치에서 /pr 커맨드 실행 시 에러 없이 동작 확인
- 기존 PR이 있는 브랜치에서 /pr 커맨드 실행 시 정상 동작 확인