### PR TITLE
fix: commit-message-convention 스킬 제약사항 및 포맷 지침 강화

### DIFF
--- a/plugins/git/skills/commit-message-convention/SKILL.md
+++ b/plugins/git/skills/commit-message-convention/SKILL.md
@@ -8,7 +8,7 @@ description: Use when writing git commit messages. Enforces conventional commit 
 
 
 # Format
-
+- STRICTLY follow the Format below
 ```
 <type>: <title>
 

--- a/plugins/git/skills/commit-message-convention/SKILL.md
+++ b/plugins/git/skills/commit-message-convention/SKILL.md
@@ -3,6 +3,10 @@ name: commit-message-convention
 description: Use when writing git commit messages. Enforces conventional commit format with Korean descriptions. Triggers on commit creation or commit message generation requests.
 ---
 
+## Constraints (CRITICAL)
+- NEVER include phrases like `Generated with Claude Code` or `Co-Authored-By: Claude` in commit messages
+
+
 # Format
 
 ```


### PR DESCRIPTION
## 1. 개요

commit-message-convention 스킬의 제약사항과 포맷 준수 지침을 강화하여 커밋 메시지 일관성을 높임.

## 2. 주요 변경 사항

- Claude 서명 제외 제약사항 추가 (`Generated with Claude Code`, `Co-Authored-By: Claude` 금지)
- 포맷 엄격 준수 지침 추가 ("STRICTLY follow the Format below" 문구)

## 3. 테스트

- 커밋 메시지 생성 시 제약사항 및 포맷이 올바르게 적용되는지 확인