### PR TITLE
fix: 커밋 메시지 포맷 지침 문구 수정

### DIFF
--- a/plugins/git/skills/commit-message-convention/SKILL.md
+++ b/plugins/git/skills/commit-message-convention/SKILL.md
@@ -8,7 +8,7 @@ description: Use when writing git commit messages. Enforces conventional commit 
 
 
 # Format
-- STRICTLY follow the Format below
+- DO NOT add any extra elements or modify the structure
 ```
 <type>: <title>
 


### PR DESCRIPTION
## 1. 개요

커밋 메시지 작성 시 정해진 포맷에 임의 요소를 추가하는 문제를 방지하기 위한 지침 문구 수정.

## 2. 주요 변경 사항

- "STRICTLY follow the Format below" 문구를 "DO NOT add any extra elements or modify the structure"로 변경
- 포맷 준수뿐 아니라 구조 변경 및 추가 요소 삽입 금지를 명확히 함

## 3. 테스트

없음