### PR TITLE
docs: SSH 인증 오류 해결 가이드 추가 및 git 플러그인 버전 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,56 @@ Claude Code에 마켓플레이스 등록
 /plugin install {plugin_name}@jiseonlee-plugins
 ```
 
+## Troubleshooting
+
+### SSH 인증 실패 오류
+
+마켓플레이스 추가 시 다음과 같은 오류가 발생하는 경우:
+
+```
+Error: Failed to clone marketplace repository: SSH authentication failed.
+git@github.com: Permission denied (publickey).
+```
+
+**해결 방법:**
+
+1. SSH 키 생성
+   ```bash
+   ssh-keygen -t ed25519 -C "your_email@example.com"
+   ```
+
+2. 키 파일 확인 (자동으로 `~/.ssh/`에 저장됨)
+   - `id_ed25519` (비밀키)
+   - `id_ed25519.pub` (공개키)
+
+3. 공개키 복사
+   ```bash
+   cat ~/.ssh/id_ed25519.pub | clip
+   ```
+
+4. GitHub에 공개키 등록
+   - [github.com](https://github.com) 접속
+   - 프로필 > Settings > SSH and GPG keys > New SSH key
+   - 복사한 공개키 붙여넣기
+
+5. SSH Agent에 키 등록
+   ```bash
+   ssh-add ~/.ssh/id_ed25519
+   ```
+
+6. 연결 테스트
+   ```bash
+   ssh -T git@github.com
+   ```
+   성공 시: `Hi {username}! You've successfully authenticated...` 메시지 출력
+
 ## Plugin 목록
 
 | 플러그인 | 버전 | 설명 |
 |---------|-----|------|
 | auto-test-generator | 0.1.0 | 시나리오 기반 테스트 코드 자동 생성 플러그인 |
 | file-context-sync | 0.1.1 | 파일 외부 변경 감지 플러그인 |
-| git | 1.0.1 | Git 작업 편의 기능을 제공하는 플러그인 |
+| git | 1.0.2 | Git 작업 편의 기능을 제공하는 플러그인 |
 | python-quality-pack | 0.1.0 | Python 개발 품질 향상을 위한 도구 모음 |
 
 ## Plugin Schema

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "git",
     "description": "Git 작업 편의 기능을 제공하는 플러그인",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": {
         "name": "JiseonLee"
     },


### PR DESCRIPTION
## 1. 개요

마켓플레이스 추가 시 SSH 인증 실패 오류를 겪는 사용자를 위한 트러블슈팅 가이드 추가 및 git 플러그인 버전 업데이트.

## 2. 주요 변경 사항

- README에 Troubleshooting 섹션 추가
  - SSH 키 생성 방법 (ed25519)
  - GitHub에 공개키 등록 절차
  - SSH Agent 등록 및 연결 테스트 방법
- git 플러그인 버전 1.0.1 -> 1.0.2 업데이트

## 3. 테스트

없음