### PR TITLE
feat(knowledge-base): Karpathy 스타일 지식 베이스 플러그인 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,6 +25,10 @@
         {
             "name": "playbook",
             "source": "./plugins/playbook"
+        },
+        {
+            "name": "knowledge-base",
+            "source": "./plugins/knowledge-base"
         }
     ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python bytecode
+__pycache__/
+*.pyc
+
+# OMC session state
+.omc/

--- a/plugins/knowledge-base/.claude-plugin/plugin.json
+++ b/plugins/knowledge-base/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+    "name": "knowledge-base",
+    "description": "Karpathy-style LLM Knowledge Base: ingest, compile, query, health-check",
+    "version": "0.1.0",
+    "author": {
+        "name": "JiseonLee"
+    },
+    "keywords": ["knowledge-base", "wiki", "knowledge-management", "llm"]
+}

--- a/plugins/knowledge-base/README.md
+++ b/plugins/knowledge-base/README.md
@@ -1,0 +1,278 @@
+# Knowledge Base Plugin
+
+Karpathy 스타일의 LLM 지식 베이스를 Claude Code 플러그인으로 구현. 소스를 수집하고, LLM이 위키를 컴파일하고, 위키 기반으로 질의하고, 품질을 관리한다.
+
+## 설정
+
+플러그인을 처음 사용할 때 `/knowledge-base:setup`을 실행해서 초기화한다.
+
+```
+/knowledge-base:setup
+```
+
+setup이 하는 일:
+- 지식 베이스 루트 경로를 대화형으로 수집 (경로 인자로 직접 지정도 가능)
+- `~/.claude/knowledge-base/config`에 경로 저장
+- 아래 디렉토리 구조 생성
+
+```
+{kb_root}/
+  raw/                    # 원본 소스 (여기로 수집)
+    images/{source}/      # URL에서 다운로드한 이미지
+  wiki/                   # LLM이 컴파일한 위키
+    index.md              # 전체 인덱스 (빈 스텁으로 시작)
+    summaries/            # 소스별 요약
+    concepts/             # 개념 문서
+    connections/          # 개념 간 관계
+  .kb_state.json          # 컴파일 상태 추적 (파일 해시, 첫 컴파일 시 생성)
+```
+
+경로를 바꾸고 싶으면 setup을 다시 실행하면 된다. 기존 데이터는 건드리지 않는다.
+
+## 커맨드
+
+### `/knowledge-base:setup [경로]`
+
+지식 베이스를 초기화한다. 처음 사용할 때 **반드시 먼저 실행**해야 한다. 다른 커맨드들은 구조가 없으면 setup 실행 안내로 막는다.
+
+```
+/knowledge-base:setup
+/knowledge-base:setup ~/Documents/my-kb
+```
+
+### `/knowledge-base:ingest <URL 또는 로컬 경로>`
+
+소스를 지식 베이스에 수집한다. 수집 후 자동으로 증분 컴파일을 실행한다.
+
+```
+/knowledge-base:ingest https://example.com/interesting-article
+/knowledge-base:ingest ./my-notes/research-paper.md
+/knowledge-base:ingest ./papers/
+```
+
+- **URL:** 페이지를 다운로드하고, 이미지를 로컬에 저장하고, LLM이 HTML을 마크다운으로 정제
+- **로컬 파일/디렉토리:** `raw/`로 복사
+
+### `/knowledge-base:compile`
+
+새로 추가되거나 수정된 raw 소스를 위키로 컴파일한다. 기본 증분 방식 (배치당 최대 10개 파일).
+
+```
+/knowledge-base:compile
+```
+
+10개 이상 대기 중이면 다시 실행해서 다음 배치를 처리한다.
+
+### `/knowledge-base:ask <질문>`
+
+컴파일된 지식 베이스를 기반으로 질문에 답변한다. RAG 없이 인덱스 기반 직접 읽기 방식.
+
+```
+/knowledge-base:ask 트랜스포머와 어텐션 메커니즘의 관계는?
+/knowledge-base:ask 최근 수집한 ML 논문의 핵심 내용을 정리해줘
+```
+
+### `/knowledge-base:health-check`
+
+지식 베이스 전체 건강 검진을 실행하고 발견된 문제를 자동 수정한다.
+
+```
+/knowledge-base:health-check
+```
+
+---
+
+## 구현 상세
+
+### 아키텍처: Prompt-Heavy / Script-Thin
+
+모든 LLM 추론 로직은 **커맨드 .md 파일**(프롬프트)에 작성되어 있고, Python 스크립트는 LLM이 직접 수행할 수 없는 **기계적 I/O 작업만** 담당한다.
+
+```
+사용자 → 슬래시 커맨드 → 커맨드 .md (LLM 프롬프트)
+                              │
+                              ├── LLM이 직접: Read, Write, Glob, Grep
+                              └── 스크립트 호출: Bash(python ...)
+                                    │
+                                    ├── kb_ingest_url.py (HTTP 다운로드)
+                                    ├── kb_compile_status.py (해시 비교)
+                                    └── kb_verify_integrity.py (구조 검증)
+```
+
+이 설계의 근거: 기존 플러그인 번들(git, daylog, playbook 등)이 모두 이 패턴을 따르고 있으며, `daylog-review.md`(84줄)가 복잡한 멀티스텝 워크플로우를 순수 프롬프트로 구현할 수 있음을 증명했다.
+
+---
+
+### `/knowledge-base:ingest` 구현 흐름
+
+```
+입력: URL 또는 로컬 파일 경로
+  │
+  ├─ URL인 경우:
+  │   1. kb_ingest_url.py 호출 (stdin JSON으로 URL 전달)
+  │      - urllib.request로 HTML 다운로드
+  │      - HTMLParser로 <img> 태그 파싱, 이미지 URL 추출
+  │      - 이미지를 raw/images/{source}/ 에 다운로드
+  │      - 결과를 stdout JSON으로 반환
+  │   2. LLM이 다운로드된 HTML을 읽고 마크다운으로 정제
+  │      - 네비게이션, 광고, 스크립트 제거
+  │      - 본문만 추출하여 깔끔한 .md로 변환
+  │      - 이미지 참조를 로컬 경로로 교체
+  │   3. raw/{source_name}.md 로 저장
+  │
+  └─ 로컬인 경우:
+      1. cp 명령으로 raw/에 복사
+      2. 디렉토리면 재귀 복사
+  │
+  └─ 이후 자동 증분 compile:
+      1. kb_compile_status.py 호출 → 새 파일 감지
+      2. LLM이 각 파일을 읽고:
+         - wiki/summaries/ 에 요약 생성
+         - wiki/concepts/ 에 개념 문서 생성/병합
+         - wiki/connections/ 에 연결 문서 생성
+         - wiki/index.md 재구축
+      3. .kb_state.json 에 해시 업데이트
+      4. kb_verify_integrity.py 로 무결성 검증
+```
+
+**핵심 포인트:**
+- `kb_ingest_url.py`는 **stdlib만** 사용 (`urllib.request`, `html.parser`) — 외부 의존성 제로
+- HTML → 마크다운 정제는 LLM이 담당 (스크립트는 단순 다운로드만)
+- ingest 후 compile이 인라인으로 실행됨 (별도 커맨드 호출 아님, 플러그인 시스템이 cross-command 호출을 미지원하므로)
+
+---
+
+### `/knowledge-base:compile` 구현 흐름
+
+```
+1. kb_compile_status.py 호출 (stdin: {"kb_root": "..."})
+   │
+   ├─ raw/ 디렉토리 스캔
+   ├─ .kb_state.json 의 기존 해시와 비교 (MD5)
+   ├─ 새 파일 / 수정된 파일 분류
+   └─ 최대 10개까지 batch 반환 (나머지는 remaining으로 보고)
+   │
+2. LLM이 batch의 각 파일을 처리:
+   │
+   ├─ 파일 읽기 (멀티모달: .md, .txt, .html, 이미지, PDF 지원)
+   │
+   ├─ 요약 생성 → wiki/summaries/{stem}.md
+   │   - YAML 메타데이터 (source, compiled date, topics)
+   │   - 3-5 단락 요약
+   │   - 관련 concept 링크
+   │
+   ├─ 개념 추출 → wiki/concepts/{concept}.md
+   │   - 파일명: lowercase-hyphenated (예: machine-learning.md)
+   │   - 기존 파일 있으면: 읽고 병합 (append 아닌 rewrite)
+   │   - 새 파일이면: 정의, 핵심 포인트, 소스 백링크
+   │
+   └─ 연결 발견 → wiki/connections/{a}--{b}.md
+       - 파일명: 알파벳순 (중복 방지)
+       - 양방향 관계 설명
+   │
+3. wiki/index.md 전체 재구축
+   - 모든 wiki 디렉토리 스캔
+   - 소스, 개념, 연결 목록 + 간략 설명
+   - 최근 추가 항목
+   - 500줄 초과 시 경고 표시
+   │
+4. .kb_state.json 업데이트 (성공한 파일만)
+   │
+5. kb_verify_integrity.py 실행 → 구조적 무결성 확인
+```
+
+**핵심 포인트:**
+- **배치 캡 10개**: context window 오버플로우 방지. 대량 파일은 여러 번 실행
+- **개념 병합(merge)**: 기존 concept 파일이 있으면 새 정보를 합쳐 재작성. append하면 중복/품질 저하
+- **인덱스 전체 재구축**: 매 컴파일마다 index.md를 처음부터 다시 생성하여 항상 최신 상태 보장
+- **상태 원자성**: `.kb_state.json`은 성공적으로 컴파일된 파일에 대해서만 해시를 업데이트. 부분 실패 시 미완료 파일은 pending 상태 유지
+
+---
+
+### `/knowledge-base:ask` 구현 흐름
+
+```
+1. wiki/index.md 읽기
+   │  (1000줄 초과 시 경고)
+   │  (wiki 비어있으면 "소스를 먼저 ingest하세요" 안내)
+   │
+2. 질문 분석 → 관련 문서 특정
+   │  - 정의 질문 → concepts/ 우선
+   │  - 소스별 질문 → summaries/ 우선
+   │  - 관계 질문 → connections/ 우선
+   │
+3. 관련 파일만 Read (전체 위키를 읽지 않음)
+   │
+4. 답변 합성
+   │  - 위키 내용에만 근거 (학습 데이터로 채우지 않음)
+   │  - 파일 경로로 출처 인용
+   │  - 답변 불가 시 명시 + ingest 제안
+   │
+5. 출력: 답변 + 출처 목록
+```
+
+**핵심 포인트:**
+- **RAG 없음**: 벡터 DB, 임베딩 없이 index.md 기반 직접 읽기. Karpathy의 핵심 인사이트 — 소규모 개인 KB에서는 인덱스가 context window에 충분히 들어간다
+- **선택적 읽기**: 인덱스에서 관련 문서만 골라 읽음. 전체 위키를 context에 넣지 않아 토큰 효율적
+- **근거 기반 답변**: LLM 학습 지식이 아닌 위키 내용만으로 답변. 위키에 없는 내용은 "답변 불가"로 명시
+
+---
+
+### `/knowledge-base:health-check` 구현 흐름
+
+```
+Phase 1: 구조적 무결성 (결정론적)
+  │  kb_verify_integrity.py 실행
+  │  - 모든 컴파일된 raw 파일에 summary 존재하는지
+  │  - connections/의 concept 참조가 실제 존재하는지
+  │  - index.md에 모든 문서가 등록되어 있는지
+  │  - 내부 마크다운 링크가 깨지지 않았는지
+  │
+Phase 2: 내용 일관성 (LLM)
+  │  - 문서 간 모순 탐지 (concept ↔ summary 교차 검증)
+  │  - 오래된 참조 발견
+  │  - 요약과 원본 소스 간 사실 일치 확인
+  │
+Phase 3: 누락 데이터 보강
+  │  - 3문장 미만의 빈약한 concept 파일 탐지
+  │  - LLM 지식으로 보충 (모든 보강 내용에 [imputed] 마커)
+  │  - (v2에서 웹 검색 기반 보강 예정)
+  │
+Phase 4: 연결 발견
+  │  - 기존 concept들 사이의 미발견 관계 탐지
+  │  - 새 connection 파일 자동 생성
+  │
+Phase 5: 자동 수정
+  │  - 누락된 summary 재생성
+  │  - 깨진 링크 수정/제거
+  │  - 고아 파일 인덱스에 등록
+  │  - index.md 전체 재구축
+  │
+Phase 6: 수정 후 재검증
+  │  kb_verify_integrity.py 재실행
+  │
+Phase 7: 리포트 출력
+   - 통계, 발견/수정 내역, 잔여 이슈
+```
+
+**핵심 포인트:**
+- **이중 검증**: 결정론적 Python 스크립트(Phase 1)가 구조를 검증하고, LLM(Phase 2)이 내용을 검증. 같은 LLM이 만든 위키를 같은 LLM이 검증하는 "같은 모델 맹점" 문제를 구조적 검증 스크립트로 보완
+- **[imputed] 마커**: LLM이 보강한 내용은 항상 표시하여 원본 데이터와 구분 가능
+- **수정 후 재검증**: 자동 수정 후 다시 integrity 스크립트를 돌려 수정이 새 문제를 만들지 않았는지 확인
+
+---
+
+### Python 스크립트 상세
+
+| 스크립트 | 줄 수 | 역할 | 입출력 |
+|---|---|---|---|
+| `kb_ingest_url.py` | 96줄 | URL HTML 다운로드 + 이미지 추출/저장 | stdin JSON → stdout JSON |
+| `kb_compile_status.py` | 87줄 | raw/ 파일 해시 비교, 새/수정 파일 감지, 배치 캡 10 | stdin JSON → stdout JSON |
+| `kb_verify_integrity.py` | 119줄 | 위키 구조적 무결성 검증 (4가지 체크) | stdin JSON → stdout JSON |
+
+모든 스크립트는 **Python stdlib만** 사용 (외부 의존성 제로):
+- `urllib.request` — HTTP 다운로드
+- `html.parser` — HTML 파싱
+- `hashlib` — MD5 해시
+- `pathlib` — 경로 처리 (Windows 호환)
+- `json` — 입출력 직렬화

--- a/plugins/knowledge-base/commands/ask.md
+++ b/plugins/knowledge-base/commands/ask.md
@@ -1,0 +1,70 @@
+---
+allowed-tools: Read, Glob, Grep
+argument-hint: <question about your knowledge base>
+description: Ask a question answered from your compiled knowledge base
+---
+
+## Context
+
+- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
+- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
+
+## Your task
+
+Answer the question in $ARGUMENTS using ONLY the knowledge base wiki content.
+
+**IMPORTANT preconditions:**
+
+- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+  > Knowledge base is not configured. Run `/knowledge-base:setup` first.
+- If KB structure shows "MISSING", stop and tell the user:
+  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+
+### Step 1: Read the index
+
+Read `<KB_ROOT>/wiki/index.md` to understand the full knowledge structure.
+
+**Size guard:** If the index exceeds 1000 lines, warn:
+> **Note:** Index is very large. Answers may be incomplete. Consider running `/knowledge-base:health-check`.
+
+If `index.md` does not exist or the wiki is empty, tell the user:
+> Knowledge base is empty. Use `/knowledge-base:ingest <URL or file>` to add sources first.
+
+### Step 2: Identify relevant documents
+
+Based on the question ($ARGUMENTS), identify which documents are most relevant:
+- Scan the index for concepts, summaries, and connections related to the question
+- Prioritize concept files for definitional questions
+- Prioritize summary files for source-specific questions
+- Prioritize connection files for relationship questions
+
+### Step 3: Read relevant documents
+
+Read the identified relevant files from `wiki/concepts/`, `wiki/summaries/`, and `wiki/connections/`. Read only what is needed to answer the question — do NOT read the entire wiki.
+
+### Step 4: Synthesize answer
+
+Compose an answer that:
+- Is **grounded in the wiki content** — do NOT use your training knowledge to fill gaps
+- **Cites sources** with relative file paths, e.g.: *(Source: [concept-name](wiki/concepts/concept-name.md))*
+- Acknowledges when information is incomplete or uncertain
+- Is well-structured with headings if the answer is complex
+
+### Step 5: Handle unanswerable questions
+
+If the question cannot be answered from the wiki:
+- State clearly: "This question cannot be answered from the current knowledge base."
+- Suggest what to ingest: "Consider ingesting sources about <topic> using `/knowledge-base:ingest`."
+- List the closest related content that IS in the wiki, if any.
+
+### Response format
+
+```markdown
+## Answer
+
+<Your grounded answer here>
+
+### Sources
+- [source-name](wiki/summaries/source-name.md)
+- [concept-name](wiki/concepts/concept-name.md)
+```

--- a/plugins/knowledge-base/commands/compile.md
+++ b/plugins/knowledge-base/commands/compile.md
@@ -1,0 +1,144 @@
+---
+allowed-tools: Bash(python:*), Bash(test:*), Read, Write, Glob, Grep
+argument-hint:
+description: Compile new raw sources into wiki (incremental, max 10 files per run)
+---
+
+## Context
+
+- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
+- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
+
+## Your task
+
+Incrementally compile new/modified raw sources into the wiki.
+
+**IMPORTANT preconditions:**
+
+- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+  > Knowledge base is not configured. Run `/knowledge-base:setup` first.
+- If KB structure shows "MISSING", stop and tell the user:
+  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+
+### Step 1: Check compile status
+
+```bash
+echo '{"kb_root": "<KB_ROOT>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_compile_status.py"
+```
+
+If `total_pending` is 0, report "Wiki is up to date. No new files to compile." and stop.
+
+### Step 2: Process each file in `batch` (max 10)
+
+For each file in the `batch` array:
+
+1. **Read the raw source file.** The LLM can read .md, .txt, .html, images (PNG, JPG), and PDFs natively.
+
+2. **Generate summary** → Write to `<KB_ROOT>/wiki/summaries/<stem>.md`:
+   ```markdown
+   ---
+   source: raw/<filename>
+   compiled: <YYYY-MM-DD>
+   topics: [topic1, topic2, ...]
+   ---
+   
+   # Summary: <Title>
+   
+   <Comprehensive 3-5 paragraph summary>
+   
+   ## Key Points
+   - Point 1
+   - Point 2
+   
+   ## Related Concepts
+   - [concept-name](../concepts/concept-name.md)
+   ```
+
+3. **Extract and write concepts** → For each key concept:
+   - Filename: lowercase-hyphenated (e.g., `neural-networks.md`)
+   - If concept file exists: Read existing content, **merge** new information (rewrite the document with combined knowledge from all sources — do NOT append)
+   - If new concept: Create `<KB_ROOT>/wiki/concepts/<concept>.md`:
+   ```markdown
+   # <Concept Name>
+   
+   <Clear definition and explanation>
+   
+   ## Key Points
+   - ...
+   
+   ## Sources
+   - [source-name](../summaries/source-name.md)
+   
+   ## Related Concepts
+   - [other-concept](other-concept.md)
+   ```
+
+4. **Discover connections** → For related concept pairs:
+   - Filename: alphabetical order, `<a>--<b>.md` (e.g., `attention--transformers.md`)
+   - Check if connection file already exists before creating
+   - Write to `<KB_ROOT>/wiki/connections/<a>--<b>.md`:
+   ```markdown
+   # <Concept A> ↔ <Concept B>
+   
+   <Description of the relationship>
+   
+   ## From <Concept A> perspective
+   - How A relates to B
+   
+   ## From <Concept B> perspective
+   - How B relates to A
+   
+   ## Sources
+   - [source](../summaries/source.md)
+   ```
+
+### Step 3: Rebuild index.md
+
+Scan all wiki directories and write `<KB_ROOT>/wiki/index.md` from scratch:
+
+```markdown
+# Knowledge Base Index
+
+*Last updated: <YYYY-MM-DD>*
+*Sources: N | Concepts: N | Connections: N*
+
+## Sources
+- [source-name](summaries/source-name.md) — brief one-line description
+
+## Concepts
+- [concept-name](concepts/concept-name.md) — brief one-line description
+
+## Connections
+- [concept-a ↔ concept-b](connections/concept-a--concept-b.md)
+
+## Recent Additions
+- <date>: Compiled <source-name>
+```
+
+**Size guard:** If index.md exceeds 500 lines, add a warning at the top:
+> **Warning:** Index is getting large (N lines). Consider organizing sub-indices for better performance.
+
+### Step 4: Update compile state
+
+Read `<KB_ROOT>/.kb_state.json`, add/update the hash for each successfully compiled file from the batch, write back.
+
+**Important:** Only update the hash for files that were **successfully** compiled (summary + concepts written).
+
+### Step 5: Verify integrity
+
+```bash
+echo '{"kb_root": "<KB_ROOT>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_verify_integrity.py"
+```
+
+Report any issues.
+
+### Step 6: Report
+
+- Files compiled: N of M pending
+- Summaries created/updated: list
+- Concepts created/updated: list
+- Connections created: list
+- Integrity: pass/fail
+- If `remaining > 0`: "**N files remaining.** Run `/knowledge-base:compile` again to process the next batch."
+
+All wiki directories (`summaries/`, `concepts/`, `connections/`) are guaranteed to exist because `/knowledge-base:setup` created them. Do NOT create directories from this command — if any are missing, that indicates a broken setup and should be reported as an error.

--- a/plugins/knowledge-base/commands/health-check.md
+++ b/plugins/knowledge-base/commands/health-check.md
@@ -1,0 +1,127 @@
+---
+allowed-tools: Bash(python:*), Bash(test:*), Read, Write, Glob, Grep
+argument-hint:
+description: Check knowledge base consistency, impute missing data, discover connections, auto-fix
+---
+
+## Context
+
+- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
+- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
+
+## Your task
+
+Run a comprehensive health check on the knowledge base and auto-fix all issues found.
+
+**IMPORTANT preconditions:**
+
+- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+  > Knowledge base is not configured. Run `/knowledge-base:setup` first.
+- If KB structure shows "MISSING", stop and tell the user:
+  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+
+### Phase 1: Structural Integrity (Deterministic)
+
+Run the verification script first:
+
+```bash
+echo '{"kb_root": "<KB_ROOT>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_verify_integrity.py"
+```
+
+This checks:
+- Every compiled raw file has a corresponding summary
+- Every concept in connections/ exists in concepts/
+- index.md lists all summaries and concepts
+- No broken internal links
+
+### Phase 2: Content Consistency (LLM)
+
+Read all wiki files and check for:
+
+1. **Contradictions** — Information in one document that contradicts another
+   - Read each concept file and cross-reference with its related summaries
+   - Flag any factual inconsistencies
+
+2. **Stale references** — Concepts that reference sources or connections that no longer exist
+   - Scan for links pointing to non-existent files
+
+3. **Factual consistency** — Summaries that don't accurately represent their source
+   - For each summary, spot-check key claims against the raw source (if readable)
+
+### Phase 3: Missing Data Imputation
+
+Identify thin content and supplement it:
+
+1. Scan all concept files for those with **less than 3 sentences** of actual content
+2. For each thin concept:
+   - Use your knowledge to add relevant information
+   - **Mark all imputed content** with `[imputed]` at the end of each added paragraph
+   - Example: "Neural networks are computational models inspired by biological neural networks. [imputed]"
+3. Note: Web search-based imputation is planned for v2. For now, use LLM training knowledge only.
+
+### Phase 4: Connection Discovery
+
+Find missing connections between existing concepts:
+
+1. Read all concept files
+2. Identify pairs of concepts that are clearly related but have no connection file
+3. For each discovered connection:
+   - Create `<KB_ROOT>/wiki/connections/<a>--<b>.md` (alphabetical order)
+   - Write bidirectional relationship description
+   - Add backlinks to both concept files
+
+### Phase 5: Auto-Fix
+
+Fix all issues found in Phases 1-4:
+
+1. **Missing summaries** — Regenerate from raw source (read raw file, create summary)
+2. **Broken links** — Fix or remove broken references
+3. **Orphaned files** — Add missing entries to index.md
+4. **Thin concepts** — Already handled in Phase 3 (imputation)
+5. **Missing connections** — Already handled in Phase 4 (discovery)
+6. **Rebuild index.md** — Regenerate from scratch to ensure completeness
+
+### Phase 6: Post-Fix Verification
+
+Run integrity check again:
+
+```bash
+echo '{"kb_root": "<KB_ROOT>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_verify_integrity.py"
+```
+
+Confirm all structural issues are resolved.
+
+### Phase 7: Report
+
+Generate a clear report:
+
+```markdown
+## Health Check Report
+
+**Date:** <YYYY-MM-DD>
+**Status:** HEALTHY | ISSUES_REMAINING
+
+### Statistics
+- Sources: N | Concepts: N | Connections: N
+- Index lines: N
+
+### Structural Issues (Phase 1)
+- Found: N | Fixed: N
+- <list of issues and fixes>
+
+### Content Issues (Phase 2)
+- Contradictions found: N
+- Stale references: N
+- <details>
+
+### Imputed Content (Phase 3)
+- Thin concepts found: N
+- Content added to: <list>
+
+### New Connections (Phase 4)
+- Discovered: N
+- <list of new connections>
+
+### Remaining Issues
+- <any unfixed issues, or "None">
+```

--- a/plugins/knowledge-base/commands/ingest.md
+++ b/plugins/knowledge-base/commands/ingest.md
@@ -1,0 +1,113 @@
+---
+allowed-tools: Bash(python:*), Bash(cp:*), Bash(test:*), Read, Write, Glob, WebFetch
+argument-hint: <URL or local file/directory path>
+description: Ingest a source into the knowledge base (URL or local file), then auto-compile
+---
+
+## Context
+
+- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
+- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
+
+## Your task
+
+Ingest the source specified in $ARGUMENTS into the knowledge base, then auto-compile it.
+
+**IMPORTANT preconditions:**
+
+- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+  > Knowledge base is not configured. Run `/knowledge-base:setup` first.
+- If KB structure shows "MISSING", stop and tell the user:
+  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+
+### Step 1: Determine source type
+
+Check if `$ARGUMENTS` starts with `http://` or `https://`:
+- **YES** → URL ingest (Step 2a)
+- **NO** → Local file ingest (Step 2b)
+
+### Step 2a: URL Ingest
+
+1. Generate a `source_name` from the URL (domain + path slug, e.g., `example_com_article-title`)
+2. **Fetch the page content using WebFetch:**
+   - Use the WebFetch tool with the URL from `$ARGUMENTS`
+   - WebFetch returns the page content as readable text/markdown
+3. **Download images using the Python script:**
+   ```bash
+   echo '{"url": "$ARGUMENTS", "kb_root": "<KB_ROOT>", "source_name": "<SOURCE_NAME>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_ingest_url.py"
+   ```
+   - The script downloads images to `raw/images/<source_name>/` and returns the list of downloaded filenames
+4. **Refine the WebFetch content into clean markdown:**
+   - Clean up any remaining noise (navigation remnants, ads, footers)
+   - Structure with proper headings, lists, links
+   - If images were downloaded, add image references using local paths: `![alt](images/<source_name>/filename.png)`
+   - Preserve all meaningful content — do not summarize at this stage
+5. Write the refined markdown to `<KB_ROOT>/raw/<source_name>.md`
+
+### Step 2b: Local File Ingest
+
+1. Check if `$ARGUMENTS` is a file or directory
+2. Copy to `<KB_ROOT>/raw/` (the directory already exists from setup):
+   - File: `cp "$ARGUMENTS" <KB_ROOT>/raw/`
+   - Directory: `cp -r "$ARGUMENTS"/* <KB_ROOT>/raw/`
+3. Report what was copied
+
+### Step 3: Auto-compile the ingested source
+
+After ingest completes, run incremental compile for the new file(s):
+
+1. Run compile status script:
+   ```bash
+   echo '{"kb_root": "<KB_ROOT>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_compile_status.py"
+   ```
+2. For each file in the `batch` array from the output:
+   a. Read the raw source file
+   b. **Generate summary** → Write to `<KB_ROOT>/wiki/summaries/<stem>.md`:
+      - Include YAML-style metadata at top: source path, date compiled, key topics
+      - Write a comprehensive summary (3-5 paragraphs)
+      - Add a "Related Concepts" section with links to `../concepts/<name>.md`
+   c. **Extract concepts** → For each key concept identified:
+      - Use lowercase-hyphenated filenames (e.g., `machine-learning.md`)
+      - If `<KB_ROOT>/wiki/concepts/<concept>.md` exists: Read it, merge new information (rewrite with combined knowledge, not append)
+      - If new: Create `<KB_ROOT>/wiki/concepts/<concept>.md` with structured content (definition, key points, related concepts with backlinks)
+   d. **Discover connections** → For pairs of related concepts:
+      - Use alphabetical ordering: `<concept-a>--<concept-b>.md` (e.g., `embeddings--transformers.md`)
+      - Write to `<KB_ROOT>/wiki/connections/<a>--<b>.md` with bidirectional description
+
+3. **Rebuild index.md** — Read all wiki directories and write `<KB_ROOT>/wiki/index.md`:
+   ```markdown
+   # Knowledge Base Index
+   
+   *Last updated: <date>*
+   *Sources: N | Concepts: N | Connections: N*
+   
+   ## Sources
+   - [source_name](summaries/source_name.md) — brief description
+   
+   ## Concepts
+   - [concept-name](concepts/concept-name.md) — brief description
+   
+   ## Connections
+   - [concept-a ↔ concept-b](connections/concept-a--concept-b.md)
+   
+   ## Recent Additions
+   - <date>: Added <source_name>
+   ```
+
+4. **Update compile state** — Read existing `.kb_state.json`, add the hash for each compiled file, write back.
+
+5. **Verify integrity:**
+   ```bash
+   echo '{"kb_root": "<KB_ROOT>"}' | python "${CLAUDE_PLUGIN_ROOT}/scripts/kb_verify_integrity.py"
+   ```
+   Report any issues found.
+
+### Step 4: Report
+
+Summarize what was done:
+- Source ingested: name, type (URL/local), size
+- Wiki updates: summaries created, concepts created/updated, connections discovered
+- Integrity check: pass/fail
+- Any errors or warnings
+
+All wiki directories (`summaries/`, `concepts/`, `connections/`) are guaranteed to exist because `/knowledge-base:setup` created them. Do NOT create directories from this command — if any are missing, that indicates a broken setup and should be reported as an error.

--- a/plugins/knowledge-base/commands/setup.md
+++ b/plugins/knowledge-base/commands/setup.md
@@ -1,0 +1,80 @@
+---
+allowed-tools: Bash(mkdir:*), Bash(test:*), Bash(ls:*), Read, Write, AskUserQuestion
+argument-hint: [optional kb_root path]
+description: Initialize the knowledge base (config + directory structure)
+---
+
+## Context
+
+- Existing config: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NONE"`
+
+## Your task
+
+Initialize the knowledge base by creating the config file and the complete directory structure.
+
+### Step 1: Determine the KB root path
+
+- If `$ARGUMENTS` is non-empty: use it as `kb_root`
+- If existing config shows a valid path: confirm with the user whether to reuse it or replace it (use `AskUserQuestion`)
+- Otherwise: ask the user where to create the knowledge base (use `AskUserQuestion` with examples like `/home/user/kb`, `./my-kb`, or `~/Documents/kb`)
+
+Expand `~` to the actual home directory before use. Normalize the path (remove trailing slash).
+
+### Step 2: Create the Claude Code config directory
+
+```bash
+mkdir -p ~/.claude/knowledge-base
+```
+
+### Step 3: Write the config file
+
+Write the resolved `kb_root` path (one line, no trailing newline) to `~/.claude/knowledge-base/config`.
+
+### Step 4: Create the knowledge base directory structure
+
+```bash
+mkdir -p <KB_ROOT>/raw/images
+mkdir -p <KB_ROOT>/wiki/summaries
+mkdir -p <KB_ROOT>/wiki/concepts
+mkdir -p <KB_ROOT>/wiki/connections
+```
+
+Replace `<KB_ROOT>` with the actual path.
+
+### Step 5: Create an empty index.md
+
+If `<KB_ROOT>/wiki/index.md` does not already exist, create it with a minimal stub:
+
+```markdown
+# Knowledge Base Index
+
+*Empty knowledge base. Use `/knowledge-base:ingest <source>` to add content.*
+```
+
+### Step 6: Verify
+
+Run `ls` on `<KB_ROOT>` to confirm the structure, then report:
+
+```markdown
+## Setup Complete
+
+- **KB root:** <path>
+- **Config:** ~/.claude/knowledge-base/config
+- **Structure created:**
+  - raw/ (with images/ subdirectory)
+  - wiki/index.md (empty stub)
+  - wiki/summaries/
+  - wiki/concepts/
+  - wiki/connections/
+
+### Next steps
+- Ingest a source: `/knowledge-base:ingest <URL or file path>`
+- Ask the knowledge base: `/knowledge-base:ask <question>`
+- Check integrity: `/knowledge-base:health-check`
+```
+
+### Edge cases
+
+- If the KB root path points to an existing non-empty directory that is NOT already a knowledge base (no `wiki/` subdirectory): warn the user before creating files inside it, and ask for confirmation.
+- If the KB root is already a knowledge base (has `wiki/index.md`): skip structure creation, just update the config file, and report "already initialized, config updated."
+- Never delete existing files. Setup is additive only.

--- a/plugins/knowledge-base/scripts/kb_compile_status.py
+++ b/plugins/knowledge-base/scripts/kb_compile_status.py
@@ -1,0 +1,99 @@
+"""Detect which raw files need compilation by comparing file hashes.
+
+Input (stdin JSON):
+    {"kb_root": "..."}
+
+Output (stdout JSON):
+    {"new_files": [...], "modified_files": [...], "total_pending": N,
+     "batch": [...], "remaining": N, "all_sources": [...]}
+
+Batch size cap: 10 files per run.
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+BATCH_SIZE = 10
+STATE_FILE = ".kb_state.json"
+SUPPORTED_EXTENSIONS = {
+    ".md", ".txt", ".html", ".pdf", ".png", ".jpg", ".jpeg", ".gif", ".svg",
+}
+
+
+def file_hash(path: Path) -> str:
+    """Compute MD5 hash of a file."""
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_state(kb_root: Path) -> dict:
+    """Load the compile state file."""
+    state_path = kb_root / STATE_FILE
+    if state_path.exists():
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    return {"compiled": {}}
+
+
+def save_state(kb_root: Path, state: dict):
+    """Save the compile state file."""
+    state_path = kb_root / STATE_FILE
+    state_path.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def scan_raw_files(raw_dir: Path) -> list[Path]:
+    """Scan raw/ for supported files, excluding images/ subdirectory."""
+    if not raw_dir.exists():
+        return []
+    files = []
+    for f in raw_dir.iterdir():
+        if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS:
+            files.append(f)
+    return sorted(files, key=lambda p: p.stat().st_mtime)
+
+
+def main():
+    data = json.loads(sys.stdin.read())
+    kb_root = Path(data["kb_root"])
+    raw_dir = kb_root / "raw"
+
+    state = load_state(kb_root)
+    compiled = state.get("compiled", {})
+
+    raw_files = scan_raw_files(raw_dir)
+    all_sources = [f.name for f in raw_files]
+
+    new_files = []
+    modified_files = []
+
+    for f in raw_files:
+        fname = f.name
+        current_hash = file_hash(f)
+
+        if fname not in compiled:
+            new_files.append({"name": fname, "path": str(f), "hash": current_hash})
+        elif compiled[fname] != current_hash:
+            modified_files.append({"name": fname, "path": str(f), "hash": current_hash})
+
+    pending = new_files + modified_files
+    total_pending = len(pending)
+    batch = pending[:BATCH_SIZE]
+    remaining = max(0, total_pending - BATCH_SIZE)
+
+    output = {
+        "new_files": [f["name"] for f in new_files],
+        "modified_files": [f["name"] for f in modified_files],
+        "total_pending": total_pending,
+        "batch": batch,
+        "remaining": remaining,
+        "all_sources": all_sources,
+    }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/knowledge-base/scripts/kb_ingest_url.py
+++ b/plugins/knowledge-base/scripts/kb_ingest_url.py
@@ -1,0 +1,125 @@
+"""Download images from a URL's HTML page to the knowledge base raw/images/ directory.
+
+HTML fetching is handled by Claude Code's WebFetch tool.
+This script only handles image downloading (binary I/O that WebFetch cannot do).
+
+Input (stdin JSON):
+    {"url": "...", "kb_root": "...", "source_name": "..."}
+
+Output (stdout JSON):
+    {"images": [...], "image_dir": "...", "source_name": "...", "errors": [...]}
+"""
+
+import json
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlretrieve, urlopen
+
+
+class ImageExtractor(HTMLParser):
+    """Extract image src attributes from HTML."""
+
+    def __init__(self, base_url: str):
+        super().__init__()
+        self.base_url = base_url
+        self.images: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):
+        if tag == "img":
+            for attr, value in attrs:
+                if attr == "src" and value:
+                    absolute = urljoin(self.base_url, value)
+                    if absolute.startswith(("http://", "https://")):
+                        self.images.append(absolute)
+
+
+def sanitize_filename(name: str) -> str:
+    """Convert a string to a safe filename."""
+    name = re.sub(r'[<>:"/\\|?*]', "_", name)
+    name = re.sub(r"\s+", "_", name)
+    return name[:100].strip("_")
+
+
+def download_page_html(url: str) -> str:
+    """Download raw HTML for image extraction only."""
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0 (KB-Plugin/0.1)"})
+    with urlopen(req, timeout=30) as resp:
+        charset = resp.headers.get_content_charset() or "utf-8"
+        return resp.read().decode(charset, errors="replace")
+
+
+def download_image(img_url: str, save_dir: Path) -> str | None:
+    """Download a single image. Returns local filename or None on failure."""
+    try:
+        parsed = urlparse(img_url)
+        filename = sanitize_filename(Path(parsed.path).name)
+        if not filename or filename == "_":
+            filename = f"image_{hash(img_url) % 10000}.jpg"
+        dest = save_dir / filename
+        if not dest.exists():
+            urlretrieve(img_url, dest)
+        return filename
+    except Exception:
+        return None
+
+
+def main():
+    data = json.loads(sys.stdin.read())
+    url = data["url"]
+    kb_root = Path(data["kb_root"])
+    source_name = data.get("source_name") or sanitize_filename(
+        urlparse(url).netloc + "_" + urlparse(url).path.strip("/")
+    )
+
+    img_dir = kb_root / "raw" / "images" / source_name
+    img_dir.mkdir(parents=True, exist_ok=True)
+
+    errors = []
+
+    # Download HTML just to extract image URLs
+    try:
+        html_content = download_page_html(url)
+    except (URLError, Exception) as e:
+        # Image download failure is non-fatal — WebFetch handles the main content
+        print(json.dumps({
+            "images": [],
+            "image_dir": None,
+            "source_name": source_name,
+            "errors": [f"Failed to fetch HTML for image extraction: {e}"],
+        }))
+        sys.exit(0)
+
+    # Extract and download images
+    extractor = ImageExtractor(url)
+    extractor.feed(html_content)
+
+    downloaded_images = []
+    for img_url in extractor.images:
+        filename = download_image(img_url, img_dir)
+        if filename:
+            downloaded_images.append(filename)
+        else:
+            errors.append(f"Failed to download image: {img_url}")
+
+    # Clean up empty image directory
+    if not downloaded_images and img_dir.exists():
+        try:
+            img_dir.rmdir()
+        except OSError:
+            pass
+
+    output = {
+        "images": downloaded_images,
+        "image_dir": str(img_dir) if downloaded_images else None,
+        "source_name": source_name,
+        "errors": errors,
+    }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/knowledge-base/scripts/kb_verify_integrity.py
+++ b/plugins/knowledge-base/scripts/kb_verify_integrity.py
@@ -1,0 +1,162 @@
+"""Verify structural integrity of the knowledge base wiki.
+
+Input (stdin JSON):
+    {"kb_root": "..."}
+
+Output (stdout JSON):
+    {"valid": true|false, "issues": [...], "stats": {...}}
+
+Checks:
+1. Every compiled raw file has a corresponding wiki/summaries/{name}.md
+2. Every concept referenced in wiki/connections/ exists in wiki/concepts/
+3. wiki/index.md lists all summaries and concepts (no orphans)
+4. No broken internal links (][...] patterns with missing targets)
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+STATE_FILE = ".kb_state.json"
+
+
+def load_state(kb_root: Path) -> dict:
+    state_path = kb_root / STATE_FILE
+    if state_path.exists():
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    return {"compiled": {}}
+
+
+def check_summaries(kb_root: Path, compiled: dict) -> list[str]:
+    """Check every compiled raw file has a summary."""
+    issues = []
+    summaries_dir = kb_root / "wiki" / "summaries"
+    for raw_name in compiled:
+        stem = Path(raw_name).stem
+        expected = summaries_dir / f"{stem}.md"
+        if not expected.exists():
+            issues.append(f"Missing summary for compiled source: {raw_name} (expected {expected.name})")
+    return issues
+
+
+def check_connections(kb_root: Path) -> list[str]:
+    """Check every concept in connections/ exists in concepts/."""
+    issues = []
+    connections_dir = kb_root / "wiki" / "connections"
+    concepts_dir = kb_root / "wiki" / "concepts"
+
+    if not connections_dir.exists():
+        return issues
+
+    for conn_file in connections_dir.glob("*.md"):
+        parts = conn_file.stem.split("--")
+        for part in parts:
+            concept_path = concepts_dir / f"{part}.md"
+            if not concept_path.exists():
+                issues.append(
+                    f"Connection '{conn_file.name}' references non-existent concept: {part}.md"
+                )
+    return issues
+
+
+def check_index(kb_root: Path) -> list[str]:
+    """Check index.md references all summaries and concepts."""
+    issues = []
+    index_path = kb_root / "wiki" / "index.md"
+
+    if not index_path.exists():
+        return ["wiki/index.md does not exist"]
+
+    index_content = index_path.read_text(encoding="utf-8")
+
+    # Check summaries are listed
+    summaries_dir = kb_root / "wiki" / "summaries"
+    if summaries_dir.exists():
+        for summary in summaries_dir.glob("*.md"):
+            if summary.name not in index_content and summary.stem not in index_content:
+                issues.append(f"Orphaned summary not in index: summaries/{summary.name}")
+
+    # Check concepts are listed
+    concepts_dir = kb_root / "wiki" / "concepts"
+    if concepts_dir.exists():
+        for concept in concepts_dir.glob("*.md"):
+            if concept.name not in index_content and concept.stem not in index_content:
+                issues.append(f"Orphaned concept not in index: concepts/{concept.name}")
+
+    return issues
+
+
+def check_broken_links(kb_root: Path) -> list[str]:
+    """Check for broken internal markdown links."""
+    issues = []
+    wiki_dir = kb_root / "wiki"
+
+    if not wiki_dir.exists():
+        return issues
+
+    link_pattern = re.compile(r"\]\(([^)]+)\)")
+
+    for md_file in wiki_dir.rglob("*.md"):
+        content = md_file.read_text(encoding="utf-8")
+        for match in link_pattern.finditer(content):
+            target = match.group(1)
+            # Skip external URLs and anchors
+            if target.startswith(("http://", "https://", "#", "mailto:")):
+                continue
+            # Resolve relative path
+            target_path = (md_file.parent / target).resolve()
+            if not target_path.exists():
+                issues.append(
+                    f"Broken link in {md_file.relative_to(wiki_dir)}: "
+                    f"'{target}' -> file not found"
+                )
+
+    return issues
+
+
+def gather_stats(kb_root: Path) -> dict:
+    """Collect wiki statistics."""
+    wiki_dir = kb_root / "wiki"
+    stats = {
+        "summaries": 0,
+        "concepts": 0,
+        "connections": 0,
+        "index_lines": 0,
+    }
+    if (wiki_dir / "summaries").exists():
+        stats["summaries"] = len(list((wiki_dir / "summaries").glob("*.md")))
+    if (wiki_dir / "concepts").exists():
+        stats["concepts"] = len(list((wiki_dir / "concepts").glob("*.md")))
+    if (wiki_dir / "connections").exists():
+        stats["connections"] = len(list((wiki_dir / "connections").glob("*.md")))
+    if (wiki_dir / "index.md").exists():
+        stats["index_lines"] = len((wiki_dir / "index.md").read_text(encoding="utf-8").splitlines())
+    return stats
+
+
+def main():
+    data = json.loads(sys.stdin.read())
+    kb_root = Path(data["kb_root"])
+
+    state = load_state(kb_root)
+    compiled = state.get("compiled", {})
+
+    all_issues = []
+    all_issues.extend(check_summaries(kb_root, compiled))
+    all_issues.extend(check_connections(kb_root))
+    all_issues.extend(check_index(kb_root))
+    all_issues.extend(check_broken_links(kb_root))
+
+    stats = gather_stats(kb_root)
+
+    output = {
+        "valid": len(all_issues) == 0,
+        "issues": all_issues,
+        "stats": stats,
+    }
+    print(json.dumps(output, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Karpathy의 "LLM Knowledge Bases" 워크플로우를 Claude Code 플러그인으로 구현. 웹/로컬 소스를 수집하고 LLM이 마크다운 위키를 점진적으로 컴파일하며, 위키 기반 Q&A와 품질 관리를 제공하는 **개인 전용** 지식 베이스 플러그인.

## 커맨드

| 커맨드 | 역할 |
|---|---|
| `/knowledge-base:setup` | 초기 설정 — config 파일 + 디렉토리 구조 생성 |
| `/knowledge-base:ingest` | URL/로컬 소스 수집 + 자동 증분 compile |
| `/knowledge-base:compile` | 증분 컴파일 (batch cap 10개) |
| `/knowledge-base:ask` | 인덱스 기반 Q&A (RAG 없음, 직접 읽기) |
| `/knowledge-base:health-check` | 구조/내용 무결성 검증 + 자동 수정 |

## 아키텍처: Prompt-Heavy / Script-Thin

모든 LLM 추론 로직은 커맨드 `.md` 프롬프트에, Python 스크립트는 I/O만 담당.

### Python 스크립트 (stdlib only, 외부 의존성 0)

- `kb_ingest_url.py` — HTTP 다운로드로 이미지 수집 (HTML 본문은 `WebFetch` 도구가 처리)
- `kb_compile_status.py` — MD5 해시 기반 변경 감지 + batch cap 10 (context overflow 방지)
- `kb_verify_integrity.py` — 결정론적 구조 무결성 검증 (LLM의 "same-model blind spots" 우회)

### 디렉토리 구조

- 설정: `~/.claude/knowledge-base/config` (kb_root 경로 평문)
- 데이터: `{kb_root}/raw/`, `{kb_root}/wiki/{summaries,concepts,connections,index.md}`

### 책임 분리

- **setup**: 디렉토리 생성의 **유일한 주체** (`Bash(mkdir:*)` 권한 보유)
- **다른 커맨드**: 구조 체크 → 없으면 "run setup first" 안내 (ad-hoc 생성 금지)

## Test plan

- [x] 헤드리스 모드에서 슬래시 커맨드 인식 확인 (`claude -p --plugin-dir ...`)
- [x] 설정 없는 상태 → "run setup first" 안내 출력 검증
- [x] 설정만 있고 디렉토리 없는 상태 → "structure missing" 안내 검증
- [x] Python 스크립트 3개 임포트 검증
- [ ] `/knowledge-base:setup` 실제 디렉토리 생성 동작 수동 테스트
- [ ] `/knowledge-base:ingest <URL>` WebFetch + 이미지 다운로드 E2E 테스트
- [ ] `/knowledge-base:compile` batch cap 10 동작 (11+ 파일 시나리오) 테스트
- [ ] `/knowledge-base:ask` 답변 + 출처 인용 품질 확인
- [ ] `/knowledge-base:health-check` 자동 수정 동작 검증

## Non-goals (v1)

- RAG / 임베딩 검색 (Karpathy 원문 기준 소규모 KB에서는 인덱스 직접 읽기가 충분)
- 외부 LLM API 직접 호출 (Claude Code 자체 LLM 활용)
- 주기적 자동 실행 / 데몬 (v2 후보)
- `compile --full` 전체 재구성 (v2 후보)
- export 커맨드 (슬라이드, matplotlib 등, v2 후보)

## Notes

- `marketplace.json`에는 knowledge-base만 추가됨 (daylog는 별도 PR로 처리 예정)
- 프로세스: Deep Interview(7% 모호성) → Ralplan 컨센서스(Architect+Critic 승인) → Autopilot 구현