### PR TITLE
fix(knowledge-base): 인터랙티브 모드 !cat 권한 에러 우회

### DIFF
--- a/plugins/knowledge-base/commands/ask.md
+++ b/plugins/knowledge-base/commands/ask.md
@@ -4,21 +4,22 @@ argument-hint: <question about your knowledge base>
 description: Ask a question answered from your compiled knowledge base
 ---
 
-## Context
-
-- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
-- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
-
 ## Your task
 
 Answer the question in $ARGUMENTS using ONLY the knowledge base wiki content.
 
-**IMPORTANT preconditions:**
+### Step 0: Read configuration and verify structure
 
-- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+Use the **Read** tool to read `~/.claude/knowledge-base/config`.
+
+- If Read fails (file not found): stop and tell the user:
   > Knowledge base is not configured. Run `/knowledge-base:setup` first.
-- If KB structure shows "MISSING", stop and tell the user:
-  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+- If Read succeeds: extract `kb_root` (file content trimmed). Then attempt to Read `<kb_root>/wiki/index.md` to verify the structure exists.
+  - If that Read fails: stop and tell the user:
+    > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+  - If both Reads succeed: proceed to Step 1 with the resolved `kb_root`. The index content from this Read can be reused in Step 1.
+
+**Important:** Do NOT use `cat` or `test` shell commands for these checks. The Read tool handles paths outside the working directory via Claude Code's tool permission flow.
 
 ### Step 1: Read the index
 

--- a/plugins/knowledge-base/commands/compile.md
+++ b/plugins/knowledge-base/commands/compile.md
@@ -1,24 +1,25 @@
 ---
-allowed-tools: Bash(python:*), Bash(test:*), Read, Write, Glob, Grep
+allowed-tools: Bash(python:*), Read, Write, Glob, Grep
 argument-hint:
 description: Compile new raw sources into wiki (incremental, max 10 files per run)
 ---
-
-## Context
-
-- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
-- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
 
 ## Your task
 
 Incrementally compile new/modified raw sources into the wiki.
 
-**IMPORTANT preconditions:**
+### Step 0: Read configuration and verify structure
 
-- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+Use the **Read** tool to read `~/.claude/knowledge-base/config`.
+
+- If Read fails (file not found): stop and tell the user:
   > Knowledge base is not configured. Run `/knowledge-base:setup` first.
-- If KB structure shows "MISSING", stop and tell the user:
-  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+- If Read succeeds: extract `kb_root` (file content trimmed). Then attempt to Read `<kb_root>/wiki/index.md` to verify the structure exists.
+  - If that Read fails: stop and tell the user:
+    > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+  - If both Reads succeed: proceed to Step 1 with the resolved `kb_root`.
+
+**Important:** Do NOT use `cat` or `test` shell commands for these checks. The Read tool handles paths outside the working directory via Claude Code's tool permission flow.
 
 ### Step 1: Check compile status
 

--- a/plugins/knowledge-base/commands/health-check.md
+++ b/plugins/knowledge-base/commands/health-check.md
@@ -1,24 +1,25 @@
 ---
-allowed-tools: Bash(python:*), Bash(test:*), Read, Write, Glob, Grep
+allowed-tools: Bash(python:*), Read, Write, Glob, Grep
 argument-hint:
 description: Check knowledge base consistency, impute missing data, discover connections, auto-fix
 ---
-
-## Context
-
-- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
-- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
 
 ## Your task
 
 Run a comprehensive health check on the knowledge base and auto-fix all issues found.
 
-**IMPORTANT preconditions:**
+### Step 0: Read configuration and verify structure
 
-- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+Use the **Read** tool to read `~/.claude/knowledge-base/config`.
+
+- If Read fails (file not found): stop and tell the user:
   > Knowledge base is not configured. Run `/knowledge-base:setup` first.
-- If KB structure shows "MISSING", stop and tell the user:
-  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+- If Read succeeds: extract `kb_root` (file content trimmed). Then attempt to Read `<kb_root>/wiki/index.md` to verify the structure exists.
+  - If that Read fails: stop and tell the user:
+    > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+  - If both Reads succeed: proceed to Phase 1 with the resolved `kb_root`.
+
+**Important:** Do NOT use `cat` or `test` shell commands for these checks. The Read tool handles paths outside the working directory via Claude Code's tool permission flow.
 
 ### Phase 1: Structural Integrity (Deterministic)
 

--- a/plugins/knowledge-base/commands/ingest.md
+++ b/plugins/knowledge-base/commands/ingest.md
@@ -1,24 +1,25 @@
 ---
-allowed-tools: Bash(python:*), Bash(cp:*), Bash(test:*), Read, Write, Glob, WebFetch
+allowed-tools: Bash(python:*), Bash(cp:*), Read, Write, Glob, WebFetch
 argument-hint: <URL or local file/directory path>
 description: Ingest a source into the knowledge base (URL or local file), then auto-compile
 ---
-
-## Context
-
-- KB root: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NOT_CONFIGURED"`
-- KB structure: !`KB=$(cat ~/.claude/knowledge-base/config 2>/dev/null); test -d "$KB/wiki" && echo "OK" || echo "MISSING"`
 
 ## Your task
 
 Ingest the source specified in $ARGUMENTS into the knowledge base, then auto-compile it.
 
-**IMPORTANT preconditions:**
+### Step 0: Read configuration and verify structure
 
-- If KB root shows "NOT_CONFIGURED", stop and tell the user:
+Use the **Read** tool to read `~/.claude/knowledge-base/config`.
+
+- If Read fails (file not found): stop and tell the user:
   > Knowledge base is not configured. Run `/knowledge-base:setup` first.
-- If KB structure shows "MISSING", stop and tell the user:
-  > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+- If Read succeeds: extract `kb_root` (file content trimmed). Then attempt to Read `<kb_root>/wiki/index.md` to verify the structure exists.
+  - If that Read fails: stop and tell the user:
+    > Knowledge base directory structure is missing. Run `/knowledge-base:setup` to initialize.
+  - If both Reads succeed: proceed to Step 1 with the resolved `kb_root`.
+
+**Important:** Do NOT use `cat` or `test` shell commands for these checks. The Read tool handles paths outside the working directory via Claude Code's tool permission flow.
 
 ### Step 1: Determine source type
 

--- a/plugins/knowledge-base/commands/setup.md
+++ b/plugins/knowledge-base/commands/setup.md
@@ -4,18 +4,22 @@ argument-hint: [optional kb_root path]
 description: Initialize the knowledge base (config + directory structure)
 ---
 
-## Context
-
-- Existing config: !`cat ~/.claude/knowledge-base/config 2>/dev/null || echo "NONE"`
-
 ## Your task
 
 Initialize the knowledge base by creating the config file and the complete directory structure.
 
+### Step 0: Check for existing config
+
+Use the **Read** tool to attempt reading `~/.claude/knowledge-base/config`.
+- If Read succeeds: extract the existing `kb_root` path (the file content, trimmed)
+- If Read fails (file not found): treat as fresh setup (no existing config)
+
+Do NOT use `cat` or any shell command for this — use the Read tool directly. The Read tool handles paths outside the working directory via Claude Code's standard permission flow (it will prompt the user for permission once if needed).
+
 ### Step 1: Determine the KB root path
 
 - If `$ARGUMENTS` is non-empty: use it as `kb_root`
-- If existing config shows a valid path: confirm with the user whether to reuse it or replace it (use `AskUserQuestion`)
+- If Step 0 found an existing valid path: confirm with the user whether to reuse it or replace it (use `AskUserQuestion`)
 - Otherwise: ask the user where to create the knowledge base (use `AskUserQuestion` with examples like `/home/user/kb`, `./my-kb`, or `~/Documents/kb`)
 
 Expand `~` to the actual home directory before use. Normalize the path (remove trailing slash).


### PR DESCRIPTION
## Summary

- Claude Code 인터랙티브 모드에서 `!cat ~/.claude/knowledge-base/config` 권한 차단 에러 수정
- `!` 백틱 Context 구문은 `allowed-tools`와 별개의 working directory 기반 보안 제약이 있어 `Bash(cat:*)` 권한으로도 우회 불가함을 확인
- Context 섹션의 `!cat`/`!test` 라인 제거, 프롬프트 본문의 Step 0에서 Read 도구로 config와 index.md를 직접 읽도록 변경 (Read는 별도 권한 모델로 절대 경로 접근 가능)
- 5개 커맨드 모두 동일 패턴 적용: `setup`, `ingest`, `compile`, `ask`, `health-check`

## Test plan

- [x] `/knowledge-base:setup` — 인터랙티브 모드 정상 동작, 디렉토리 구조 생성 확인
- [x] `/knowledge-base:compile` — 5개 raw 파일을 summaries/concepts/connections로 컴파일, verify_integrity 통과
- [x] `/knowledge-base:ask` — 위키 기반 Q&A 정상 동작, 출처 인용 포함
- [ ] `/knowledge-base:ingest` — URL 수집 + 자동 compile 동작 (미검증)
- [ ] `/knowledge-base:health-check` — 검증 + 자동 수정 동작 (미검증)